### PR TITLE
Apply edited sections and simplify date defaults

### DIFF
--- a/actions/cause-actions.ts
+++ b/actions/cause-actions.ts
@@ -589,6 +589,26 @@ export async function updateCauseStatus(
         throw updateError;
       }
 
+      const { data: editSections } = await supabaseAdmin
+        .from("cause_edit_sections")
+        .select("heading, description")
+        .eq("cause_edit_id", edit.id);
+
+      if (editSections && editSections.length > 0) {
+        await supabaseAdmin
+          .from("cause_sections")
+          .delete()
+          .eq("cause_id", causeId);
+
+        const newSections = editSections.map((section: any) => ({
+          cause_id: causeId,
+          heading: section.heading,
+          description: section.description,
+        }));
+
+        await supabaseAdmin.from("cause_sections").insert(newSections);
+      }
+
       await supabaseAdmin.from("cause_edits").delete().eq("id", edit.id);
 
       revalidatePath("/dashboard/admin/causes");

--- a/app/dashboard/causes/[id]/edit/edit-cause-form.tsx
+++ b/app/dashboard/causes/[id]/edit/edit-cause-form.tsx
@@ -138,10 +138,10 @@ export default function EditCauseForm({ cause }: EditCauseFormProps) {
     coverImage: null,
     image: cause.image || "",
     sections: cause.sections || [{ heading: "", description: "" }],
-    startDate: cause.created_at ? new Date(cause.created_at) : (cause.days_active ? new Date() : undefined),
-    endDate: (cause.created_at && cause.days_active)
-      ? new Date(new Date(cause.created_at).getTime() + cause.days_active * 24 * 60 * 60 * 1000)
-      : (cause.days_active ? new Date(Date.now() + cause.days_active * 24 * 60 * 60 * 1000) : undefined),
+    startDate: new Date(),
+    endDate: cause.days_active != null 
+      ? new Date(Date.now() + cause.days_active * 24 * 60 * 60 * 1000) 
+      : undefined,
     multimedia: cause.multimedia || [],
     videoLinks: (cause as any).video_links || [],
   });


### PR DESCRIPTION
When updating a cause status, fetch any rows from cause_edit_sections for the edit and, if present, replace the existing cause_sections for that cause with the edited sections before deleting the cause_edit record and revalidating. Also simplify the EditCauseForm initial state: set startDate to now and compute endDate only from days_active (if present), replacing the previous created_at-based logic to make date defaults more predictable.