### PR TITLE
Add health check endpoints and referral reward logic

### DIFF
--- a/actions/kyc-actions.ts
+++ b/actions/kyc-actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 import { KycVerification, KycStatus } from "@/types/kyc-types";
 import { logAdminActivity } from "@/actions/database-actions";
@@ -251,6 +252,60 @@ export async function getVerificationStatus(
   }
 }
 
+type PendingReferralRow = {
+  id_v1: string;
+  referrer_id_v1: string;
+};
+
+async function issueReferralRewardOnKycApproval(refereeUserId: string) {
+  const referrals = await prisma.$queryRaw<PendingReferralRow[]>(Prisma.sql`
+    SELECT id_v1, referrer_id_v1
+    FROM referrals_v1
+    WHERE referee_id_v1 = CAST(${refereeUserId} AS uuid)
+      AND reward_status_v1 = 'PENDING'
+    ORDER BY created_at_v1 DESC
+    LIMIT 1
+  `);
+
+  const referral = referrals[0];
+  if (!referral?.referrer_id_v1) {
+    return;
+  }
+
+  await prisma.$transaction(async (tx) => {
+    const lockedReferralCount = await tx.$executeRaw(Prisma.sql`
+      UPDATE referrals_v1
+      SET
+        reward_status_v1 = 'ISSUED',
+        kyc_verified_v1 = true,
+        rewarded_at_v1 = NOW(),
+        reward_v1 = '+5 pts'
+      WHERE id_v1 = CAST(${referral.id_v1} AS uuid)
+        AND reward_status_v1 = 'PENDING'
+    `);
+
+    if (lockedReferralCount === 0) {
+      return;
+    }
+
+    await tx.user.update({
+      where: { id: referral.referrer_id_v1 },
+      data: {
+        total_points: { increment: 5 },
+      },
+    });
+
+    await tx.rewardTransaction.create({
+      data: {
+        userId: referral.referrer_id_v1,
+        amount: 5,
+        transactionType: "referral_bonus",
+        status: "completed",
+      },
+    });
+  });
+}
+
 export async function updateVerificationStatus(
   verificationId: string,
   status: "approved" | "rejected",
@@ -322,50 +377,13 @@ export async function updateVerificationStatus(
           data: { isVerified: true },
         });
 
-        const referral = await prisma.referrals_v1.findFirst({
-          where: {
-            referee_id_v1: verification.user_id,
-            reward_status_v1: "PENDING",
-          },
-        });
-
-        if (referral) {
-          await prisma.$transaction(async (tx) => {
-            // 🔒 STEP 1: Hard lock to prevent duplicate reward
-            const lockedReferral = await tx.referrals_v1.updateMany({
-              where: {
-                id_v1: referral.id_v1,
-                reward_status_v1: "PENDING", // ensures it can only run once
-              },
-              data: {
-                reward_status_v1: "ISSUED",
-                kyc_verified_v1: true,
-                rewarded_at_v1: new Date(),
-                reward_v1: "+5 pts",
-              },
-            });
-
-            // If nothing was updated, reward already processed → exit safely
-            if (lockedReferral.count === 0) return;
-
-            // 💰 STEP 2: Credit referrer
-            await tx.user.update({
-              where: { id: referral.referrer_id_v1! },
-              data: {
-                total_points: { increment: 5 },
-              },
-            });
-
-            // 🧾 STEP 3: Log transaction
-            await tx.rewardTransaction.create({
-              data: {
-                userId: referral.referrer_id_v1!,
-                amount: 5,
-                transactionType: "referral_bonus",
-                status: "completed",
-              },
-            });
-          });
+        try {
+          await issueReferralRewardOnKycApproval(verification.user_id);
+        } catch (referralError) {
+          console.error(
+            "[KYC] Referral reward failed after approval:",
+            referralError,
+          );
         }
       } else if (status === "rejected") {
         await prisma.user.update({

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import {
+  isHealthCheckAuthorized,
+  runHealthChecks,
+} from "@/lib/health/checks";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  if (!isHealthCheckAuthorized(request)) {
+    return NextResponse.json(
+      {
+        status: "unavailable",
+        services: {
+          database: "unavailable",
+          bookings: "unavailable",
+          payments: "unavailable",
+        },
+        timestamp: new Date().toISOString(),
+      },
+      {
+        status: 401,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  const health = await runHealthChecks();
+  const httpStatus = health.status === "operational" ? 200 : 503;
+
+  return NextResponse.json(health, {
+    status: httpStatus,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/lib/health/checks.ts
+++ b/lib/health/checks.ts
@@ -1,0 +1,123 @@
+import { prisma } from "@/lib/prisma";
+import type { HealthCheckResponse, ServiceStatus } from "@/lib/health/types";
+
+const CHECK_TIMEOUT_MS = 5_000;
+
+async function runWithTimeout<T>(
+  label: string,
+  task: () => Promise<T>,
+  timeoutMs = CHECK_TIMEOUT_MS,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      task(),
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`${label} timed out`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+async function checkDatabase(): Promise<ServiceStatus> {
+  try {
+    await runWithTimeout("database", () => prisma.$queryRaw`SELECT 1`);
+    return "operational";
+  } catch (error) {
+    console.error("[health] database check failed");
+    return "unavailable";
+  }
+}
+
+/**
+ * Bookings maps to the pledge scheduling subsystem (scheduled donation commitments).
+ */
+async function checkBookings(): Promise<ServiceStatus> {
+  try {
+    await runWithTimeout("bookings", () =>
+      prisma.pledges.findFirst({
+        select: { id: true },
+      }),
+    );
+    return "operational";
+  } catch (error) {
+    console.error("[health] bookings check failed");
+    return "unavailable";
+  }
+}
+
+async function checkPayments(): Promise<ServiceStatus> {
+  const secretKey = process.env.PAYSTACK_SECRET_KEY?.trim();
+
+  if (!secretKey) {
+    console.error("[health] payments check failed: missing configuration");
+    return "unavailable";
+  }
+
+  try {
+    const response = await runWithTimeout(
+      "payments",
+      () =>
+        fetch("https://api.paystack.co/bank?currency=NGN&perPage=1", {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${secretKey}`,
+            Accept: "application/json",
+          },
+          cache: "no-store",
+          signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+        }),
+    );
+
+    if (!response.ok) {
+      console.error("[health] payments check failed: upstream unavailable");
+      return "unavailable";
+    }
+
+    return "operational";
+  } catch (error) {
+    console.error("[health] payments check failed");
+    return "unavailable";
+  }
+}
+
+export async function runHealthChecks(): Promise<HealthCheckResponse> {
+  const [database, bookings, payments] = await Promise.all([
+    checkDatabase(),
+    checkBookings(),
+    checkPayments(),
+  ]);
+
+  const services = { database, bookings, payments };
+  const status =
+    Object.values(services).every((service) => service === "operational")
+      ? "operational"
+      : "unavailable";
+
+  return {
+    status,
+    services,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function isHealthCheckAuthorized(request: Request): boolean {
+  const expectedToken = process.env.HEALTH_CHECK_TOKEN?.trim();
+
+  if (!expectedToken) {
+    return true;
+  }
+
+  const bearer = request.headers.get("authorization");
+  const headerToken = request.headers.get("x-health-check-token");
+  const providedToken = bearer?.replace(/^Bearer\s+/i, "").trim() || headerToken;
+
+  return providedToken === expectedToken;
+}

--- a/lib/health/types.ts
+++ b/lib/health/types.ts
@@ -1,0 +1,13 @@
+export type ServiceStatus = "operational" | "unavailable";
+
+export type HealthStatus = "operational" | "unavailable";
+
+export type HealthCheckResponse = {
+  status: HealthStatus;
+  services: {
+    database: ServiceStatus;
+    bookings: ServiceStatus;
+    payments: ServiceStatus;
+  };
+  timestamp: string;
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,7 @@ import { auth } from "@/lib/auth/auth";
  */
 const PUBLIC_API_PREFIXES = [
   "/api/auth", // NextAuth routes
+  "/api/health", // Monitoring health checks
   "/api/bot", // Developer API — authenticated via API keys
   "/api/webhooks", // Incoming webhooks (Paystack, etc.)
   "/api/payments", // Guest donation checkout + verification


### PR DESCRIPTION
- Introduced a new health check API endpoint at /api/health for monitoring service status.
- Implemented health check logic to verify database, bookings, and payments services.
- Added a function to issue referral rewards upon KYC approval, improving transaction safety and readability.
- Updated middleware to include the new health check route in public API prefixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public health-check endpoint that returns service status and overall app health.
  * Health checks now include database, booking, and payment service status details.

* **Bug Fixes**
  * Improved KYC approval flow so referral rewards are processed separately and won’t block approval if reward issuing fails.
  * Allowed health-check requests without a user session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->