### PR TITLE
fix-cause-mobile-bug

### DIFF
--- a/app/dashboard/causes/create/create-cause-form.tsx
+++ b/app/dashboard/causes/create/create-cause-form.tsx
@@ -530,13 +530,16 @@ export default function CreateCauseForm() {
       video_links: formData.videoLinks,
     };
     try {
-      await sendCauseUnderReviewEmail({
+      await createCause(user.id, causeData);
+      localStorage.removeItem("causeDraft");
+
+      sendCauseUnderReviewEmail({
         causeName: causeData.title,
         reviewTimeframe: "3-5 business days",
         dashboardUrl: `${window.location.origin}/dashboard/causes`,
+      }).catch((error) => {
+        console.error("Failed to send cause-under-review email:", error);
       });
-      await createCause(user.id, causeData);
-      localStorage.removeItem("causeDraft");
 
       router.push("/dashboard/causes");
     } catch (error) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@aws-sdk/client-ec2": "^3.1041.0",
     "@aws-sdk/client-s3": "^3.1040.0",
     "@aws-sdk/s3-request-presigner": "^3.1040.0",
+    "@didit-protocol/sdk-web": "^0.2.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@heroui/navbar": "^2.2.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1040.0
         version: 3.1041.0
+      '@didit-protocol/sdk-web':
+        specifier: ^0.2.1
+        version: 0.2.1
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.1.0)(react@19.1.0)
@@ -1270,6 +1273,10 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@didit-protocol/sdk-web@0.2.1':
+    resolution: {integrity: sha512-dv5mrvgV6RJgXySWIcDFwp9AMD7Hz9AN/GbDIhmZMRHpSumiIb44XP9MhUaF7YgWbtscRJhkbDH0KgHzSO6hJg==}
+    engines: {node: '>=16.0.0'}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -8376,6 +8383,8 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@didit-protocol/sdk-web@0.2.1': {}
 
   '@emnapi/core@1.9.2':
     dependencies:


### PR DESCRIPTION
The review email was awaited before createCause, both wrapped in a try/catch that only logged to console. Any failure in the email step (more likely on flaky mobile connections) silently aborted the whole submission with no user-facing error. createCause now runs first and the email is fire-and-forget.

Also adds @didit-protocol/sdk-web, which was imported by the KYC setup form but never installed, breaking that page entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cause submissions are now created before drafts are removed and review notifications are sent.
  * Email delivery failures no longer prevent successful cause submissions.

* **New Features**
  * Added support for the Didit Protocol web SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->