### PR TITLE
Support Flutterwave subaccounts and improve errors

### DIFF
--- a/app/api/payments/initialize/route.ts
+++ b/app/api/payments/initialize/route.ts
@@ -128,6 +128,16 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Ensure Flutterwave gets its specific subaccount ID, not the Paystack one
+    if (data.paymentProvider === "flutterwave" && data._flutterwaveSubAccountId) {
+      data.subaccounts = [
+        {
+          subaccount: data._flutterwaveSubAccountId,
+          share: Number(data.amount) * 100,
+        },
+      ];
+    }
+
     const response = await initializeTransaction(data, data.paymentProvider);
 
     return NextResponse.json({

--- a/services/flutterwave.ts
+++ b/services/flutterwave.ts
@@ -96,10 +96,13 @@ const Flutterwave = {
         data: error.response?.data?.message,
       });
 
-      throw new Error(
-        error.response?.data?.message ||
-          "Failed to initialize payment transaction"
-      );
+      let errorMessage = error.response?.data?.message || "Failed to initialize payment transaction";
+      if (error.response?.data?.errors && Array.isArray(error.response.data.errors)) {
+        const details = error.response.data.errors.map((e: any) => e.message).join(", ");
+        errorMessage += `: ${details}`;
+      }
+
+      throw new Error(errorMessage);
     }
   },
 

--- a/types/common-types.ts
+++ b/types/common-types.ts
@@ -83,6 +83,7 @@ export interface TransactionData
   pledgeId?: string;
   pledgeFutureAmount?: number;
   reminderDate?: string;
+  _flutterwaveSubAccountId?: string;
 }
 
 export interface ICreateSubaccount {


### PR DESCRIPTION
Add Flutterwave-specific subaccount handling and better error messages.

- app/api/payments/initialize/route.ts: When paymentProvider is "flutterwave" and a _flutterwaveSubAccountId is provided, populate data.subaccounts so Flutterwave receives its own subaccount (share calculated as amount * 100).
- services/flutterwave.ts: Aggregate detailed error messages from response.data.errors into the thrown Error to make failures clearer.
- types/common-types.ts: Add _flutterwaveSubAccountId to TransactionData so the field is typed.