### PR TITLE
Fix unit tests broken by donation/petition stat fixes

### DIFF
--- a/tests/actions/donation-actions.test.ts
+++ b/tests/actions/donation-actions.test.ts
@@ -232,7 +232,12 @@ describe("donation-actions", () => {
           amount: 5000,
           tip_amount: 0,
           createdAt: new Date("2026-01-01T00:00:00.000Z"),
-          cause: { title: "Help School", category: "education", slug: null },
+          cause: {
+            title: "Help School",
+            category: "education",
+            status: "approved",
+            slug: null,
+          },
         },
       ]);
 
@@ -241,6 +246,7 @@ describe("donation-actions", () => {
       expect(result[0].cause).toEqual({
         title: "Help School",
         category: "education",
+        status: "approved",
         slug: null,
       });
     });

--- a/tests/actions/petition-actions.test.ts
+++ b/tests/actions/petition-actions.test.ts
@@ -23,6 +23,9 @@ jest.mock("@/lib/prisma", () => ({
       createMany: jest.fn(),
       deleteMany: jest.fn(),
     },
+    signatures: {
+      groupBy: jest.fn(),
+    },
     user: {
       findUnique: jest.fn(),
     },
@@ -91,6 +94,7 @@ const mockPrisma = prisma as unknown as {
     delete: jest.Mock;
   };
   petition_edit_sections: { createMany: jest.Mock; deleteMany: jest.Mock };
+  signatures: { groupBy: jest.Mock };
   user: { findUnique: jest.Mock };
 };
 
@@ -305,10 +309,14 @@ describe("petition-actions", () => {
           updated_at: updatedAt,
         },
       ]);
+      mockPrisma.signatures.groupBy.mockResolvedValue([
+        { petition_id: "petition-1", _count: { petition_id: 3 } },
+      ]);
 
       const result = await getUserPetitions("owner-1");
 
       expect(result[0].goal).toBe(100);
+      expect(result[0].signatures).toBe(3);
       expect(mockPrisma.petitions.findMany).toHaveBeenCalledWith({
         where: { user_id: "owner-1" },
         orderBy: { created_at: "desc" },


### PR DESCRIPTION
## Summary
- PR #419 merged into `main`, but its CI test gate failed, so `build-and-deploy` never ran — none of that PR's fixes (donation recording, dashboard/profile stats) are actually live on production yet.
- `listUserDonations` (actions/donation-actions.ts) now selects `cause.status`, and `getUserPetitions` (actions/petition-actions.ts) now queries signature counts via `prisma.signatures.groupBy`. The existing unit tests predated both changes and didn't mock/assert for them, which is what failed CI.
- This PR only updates the two affected test files to match the already-merged behavior — no production code changes.

## Test plan
- [x] `pnpm run test:no-coverage` — 420/420 passing locally
- [x] `pnpm run lint` — passes (one pre-existing unrelated warning)
- [ ] Confirm this run's CI gate is green, then production deploy proceeds automatically on merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)