### PR TITLE
Fix session appearing lost on public profile pages

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -55,9 +55,45 @@ const customAdapter: Adapter = {
   },
 };
 
+// The app is split across apps.refreeg.com (logged-in routes) and
+// www.refreeg.com / refreeg.com (public routes, including /[username]
+// profile pages). Without a shared cookie domain, the session cookie set on
+// apps.refreeg.com never reaches those public-host pages, so a logged-in
+// user's session appears to vanish there. csrfToken intentionally keeps the
+// default host-only scoping — its __Host- prefix forbids a Domain attribute.
+const cookieDomain = process.env.AUTH_COOKIE_DOMAIN;
+const useSecureCookies = process.env.AUTH_URL?.startsWith("https://") ?? true;
+const cookiePrefix = useSecureCookies ? "__Secure-" : "";
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: customAdapter,
   session: { strategy: "jwt" },
+  ...(cookieDomain
+    ? {
+        cookies: {
+          sessionToken: {
+            name: `${cookiePrefix}authjs.session-token`,
+            options: {
+              httpOnly: true,
+              sameSite: "lax",
+              path: "/",
+              secure: useSecureCookies,
+              domain: cookieDomain,
+            },
+          },
+          callbackUrl: {
+            name: `${cookiePrefix}authjs.callback-url`,
+            options: {
+              httpOnly: true,
+              sameSite: "lax",
+              path: "/",
+              secure: useSecureCookies,
+              domain: cookieDomain,
+            },
+          },
+        },
+      }
+    : {}),
   providers: [
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID!,


### PR DESCRIPTION
## Summary
- The app splits traffic across `apps.refreeg.com` (logged-in routes: dashboard, causes, etc.) and `www.refreeg.com`/`refreeg.com` (public routes, including `/[username]` profile pages) — see `middleware.ts`.
- `lib/auth/auth.ts` had no explicit cookie domain configured, so the NextAuth session cookie was scoped to whichever host you logged in on (typically `apps.refreeg.com`). Visiting a profile page on the other host meant the browser didn't send that cookie, so the page rendered as logged out even with an active session — this is what looked like being randomly signed out.
- Adds a `cookies` config that shares the session and callback-url cookies across `*.refreeg.com` when the new `AUTH_COOKIE_DOMAIN` env var is set. `csrfToken` intentionally keeps its default host-only scope — its `__Host-` prefix forbids a `Domain` attribute, so sharing it would silently break the cookie (and login).

## Deploy note
This is a no-op until `AUTH_COOKIE_DOMAIN=.refreeg.com` is added to the production environment. After that's set and this deploys, **every currently-logged-in user will need to log in once more** (existing cookies don't have the shared-domain scope) — after that, this class of bug should be gone for good.

## Test plan
- [x] `pnpm run test:no-coverage` — all passing, no existing tests touch this code path
- [x] `pnpm run lint` — passes
- [ ] Set `AUTH_COOKIE_DOMAIN=.refreeg.com` in production env before/at merge time
- [ ] After deploy, confirm logging in on `apps.refreeg.com` then visiting a `/[username]` profile page keeps the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)