### PR TITLE
Fix login session persisting indefinitely

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -8,6 +8,14 @@ import type { UserRole } from "@/types/role-types";
 import bcrypt from "bcryptjs";
 import { headers } from "next/headers";
 
+// Idle timeout: session cookie/JWT expiry, renewed on activity (sliding window).
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7; // 7 days
+// How often the sliding window is renewed while the user is active.
+const SESSION_UPDATE_AGE_SECONDS = 60 * 60 * 24; // 1 day
+// Absolute cap on a session's lifetime, regardless of activity, so a
+// continuously-active session cannot renew itself forever.
+const ABSOLUTE_SESSION_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
+
 async function resolveUserRole(userId: string): Promise<UserRole> {
   const role = await prisma.role.findFirst({
     where: { user_id: userId },
@@ -57,7 +65,11 @@ const customAdapter: Adapter = {
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: customAdapter,
-  session: { strategy: "jwt" },
+  session: {
+    strategy: "jwt",
+    maxAge: SESSION_MAX_AGE_SECONDS,
+    updateAge: SESSION_UPDATE_AGE_SECONDS,
+  },
   providers: [
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID!,
@@ -211,11 +223,25 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   },
   callbacks: {
     async jwt({ token, user, trigger, session }) {
+      // Enforce an absolute session lifetime regardless of activity, so a
+      // continuously-active session can't renew its sliding window forever.
+      // Returning null here invalidates the token and clears the cookie.
+      if (
+        !user &&
+        typeof token.loginTime === "number" &&
+        Date.now() - token.loginTime > ABSOLUTE_SESSION_MAX_AGE_MS
+      ) {
+        return null;
+      }
+
       const userId = user?.id;
       if (userId) {
+        // Stamp the original sign-in time; this persists across token
+        // refreshes since we only set it when a fresh `user` is present.
+        token.loginTime = Date.now();
         token.id = userId;
         token.onboardingCompleted = (user as any).onboarding_completed;
-        
+
         // If the role was already fetched during credentials authorize, use it
         if ((user as any).role) {
           token.role = (user as any).role;

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -24,5 +24,8 @@ declare module "next-auth/jwt" {
     id?: string;
     onboardingCompleted?: boolean | null;
     role?: UserRole;
+    tier?: string;
+    /** Epoch ms when this session was originally created; used to enforce an absolute session lifetime. */
+    loginTime?: number;
   }
 }


### PR DESCRIPTION
NextAuth's JWT session had no explicit maxAge/updateAge, so it defaulted to a 30-day idle window that renews on every request with no absolute cap — an active user was effectively never signed out. Set an explicit 7-day sliding idle timeout and add a 30-day absolute session lifetime enforced in the jwt callback (returns null to invalidate/clear the cookie once exceeded, regardless of activity).